### PR TITLE
Add Fibonacci HTTP endpoint and tests

### DIFF
--- a/fib/api.py
+++ b/fib/api.py
@@ -1,0 +1,46 @@
+"""Minimal HTTP server exposing a Fibonacci endpoint."""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+import json
+
+from .core import fibonacci
+
+
+class FibRequestHandler(BaseHTTPRequestHandler):
+    """Handle GET requests for Fibonacci numbers."""
+
+    def do_GET(self) -> None:  # noqa: N802 (for method name; though no flake8 here)
+        parsed = urlparse(self.path)
+        if parsed.path != "/fib/":
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+        if "n" not in params:
+            self.send_error(400, "missing n parameter")
+            return
+        try:
+            n = int(params["n"][0])
+            value = fibonacci(n)
+        except (ValueError, TypeError):
+            self.send_error(400, "invalid n parameter")
+            return
+
+        body = json.dumps({"n": n, "value": value}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def run(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Run the HTTP server."""
+    server = HTTPServer((host, port), FibRequestHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/fib/core.py
+++ b/fib/core.py
@@ -1,0 +1,26 @@
+"""Core Fibonacci logic."""
+
+def fibonacci(n: int) -> int:
+    """Return the nth Fibonacci number.
+
+    Parameters
+    ----------
+    n: int
+        Non-negative index of the Fibonacci sequence.
+
+    Returns
+    -------
+    int
+        The Fibonacci number at position n.
+
+    Raises
+    ------
+    ValueError
+        If n is negative.
+    """
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    a, b = 0, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,52 @@
+"""Tests for the Fibonacci HTTP API."""
+
+from threading import Thread
+from http.server import HTTPServer
+import json
+import urllib.request
+import urllib.error
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fib.api import FibRequestHandler
+
+
+def start_server() -> tuple[HTTPServer, Thread]:
+    """Start the HTTP server in a background thread."""
+    server = HTTPServer(("127.0.0.1", 0), FibRequestHandler)
+    thread = Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server, thread
+
+
+def stop_server(server: HTTPServer, thread: Thread) -> None:
+    server.shutdown()
+    thread.join()
+
+
+def test_get_fibonacci() -> None:
+    server, thread = start_server()
+    url = f"http://{server.server_name}:{server.server_port}/fib/?n=10"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            assert resp.status == 200
+            data = json.loads(resp.read().decode())
+            assert data == {"n": 10, "value": 55}
+    finally:
+        stop_server(server, thread)
+
+
+def test_get_fibonacci_negative() -> None:
+    server, thread = start_server()
+    url = f"http://{server.server_name}:{server.server_port}/fib/?n=-1"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            # Should raise HTTPError for status >=400
+            pass
+    except urllib.error.HTTPError as err:
+        assert err.code == 400
+    finally:
+        stop_server(server, thread)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,19 @@
+"""Tests for Fibonacci core logic."""
+
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fib.core import fibonacci
+
+
+@pytest.mark.parametrize("n,expected", [(0, 0), (1, 1), (5, 5), (10, 55)])
+def test_fibonacci_values(n: int, expected: int) -> None:
+    assert fibonacci(n) == expected
+
+
+def test_fibonacci_negative() -> None:
+    with pytest.raises(ValueError):
+        fibonacci(-1)


### PR DESCRIPTION
## Summary
- implement core Fibonacci calculation
- expose `/fib/` REST endpoint using Python's built-in HTTP server
- add unit tests for Fibonacci logic and API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a7b453d083338812cdeb4a72030f