### PR TITLE
Add CI workflow to run pytest via Gitea Actions

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- Add Gitea Actions workflow to run tests with pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ab67ccec8333b8e7ba7b6e42de5e