### PR TITLE
Add flake8 linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install pytest
+        run: pip install pytest flake8
+      - name: Run lint
+        run: flake8
       - name: Run tests
         run: pytest

--- a/fib/api.py
+++ b/fib/api.py
@@ -10,7 +10,7 @@ from .core import fibonacci
 class FibRequestHandler(BaseHTTPRequestHandler):
     """Handle GET requests for Fibonacci numbers."""
 
-    def do_GET(self) -> None:  # noqa: N802 (for method name; though no flake8 here)
+    def do_GET(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
         if parsed.path != "/fib/":
             self.send_error(404)

--- a/fib/core.py
+++ b/fib/core.py
@@ -1,5 +1,6 @@
 """Core Fibonacci logic."""
 
+
 def fibonacci(n: int) -> int:
     """Return the nth Fibonacci number.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from fib.api import FibRequestHandler
+from fib.api import FibRequestHandler  # noqa: E402
 
 
 def start_server() -> tuple[HTTPServer, Thread]:
@@ -43,7 +43,7 @@ def test_get_fibonacci_negative() -> None:
     server, thread = start_server()
     url = f"http://{server.server_name}:{server.server_port}/fib/?n=-1"
     try:
-        with urllib.request.urlopen(url) as resp:
+        with urllib.request.urlopen(url):
             # Should raise HTTPError for status >=400
             pass
     except urllib.error.HTTPError as err:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from fib.core import fibonacci
+from fib.core import fibonacci  # noqa: E402
 
 
 @pytest.mark.parametrize("n,expected", [(0, 0), (1, 1), (5, 5), (10, 55)])


### PR DESCRIPTION
## Summary
- run flake8 in CI pipeline
- trim long comment in API handler so flake8 passes

## Testing
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c6029e7883338c0dad5f4aa300e8