### PR TITLE
Fix flake8 issues

### DIFF
--- a/fib/core.py
+++ b/fib/core.py
@@ -1,5 +1,6 @@
 """Core Fibonacci logic."""
 
+
 def fibonacci(n: int) -> int:
     """Return the nth Fibonacci number.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from fib.api import FibRequestHandler
+from fib.api import FibRequestHandler  # noqa: E402
 
 
 def start_server() -> tuple[HTTPServer, Thread]:
@@ -43,7 +43,7 @@ def test_get_fibonacci_negative() -> None:
     server, thread = start_server()
     url = f"http://{server.server_name}:{server.server_port}/fib/?n=-1"
     try:
-        with urllib.request.urlopen(url) as resp:
+        with urllib.request.urlopen(url):
             # Should raise HTTPError for status >=400
             pass
     except urllib.error.HTTPError as err:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from fib.core import fibonacci
+from fib.core import fibonacci  # noqa: E402
 
 
 @pytest.mark.parametrize("n,expected", [(0, 0), (1, 1), (5, 5), (10, 55)])


### PR DESCRIPTION
## Summary
- satisfy flake8 by adding missing blank line in fib/core
- tidy test imports and remove unused variables

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895971973b88333be2061b948e9da0e