### PR TITLE
Add flake8 linting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install pytest
+        run: pip install pytest flake8
+      - name: Lint
+        run: flake8
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary
- run flake8 during GitHub Actions CI

## Testing
- `flake8` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959a458cf88333b169da463e5f7a28